### PR TITLE
chore: remove `-SNAPSHOT` qualifier from version to fix semantic-release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>io.gravitee.policy</groupId>
     <artifactId>gravitee-policy-retry</artifactId>
-    <version>1.2.0-SNAPSHOT</version>
+    <version>1.2.0</version>
 
     <name>Gravitee.io APIM - Policy - Retry</name>
     <description>Description of the Retry Gravitee Policy</description>


### PR DESCRIPTION
**Description**

Add missing step after the setup of `semantic-release`: https://github.com/gravitee-io/gravitee-policy-retry/pull/7