### PR TITLE
Small tooling improvements

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,7 @@
 = Retry policy
 
 ifdef::env-github[]
+image:https://img.shields.io/static/v1?label=Available%20at&message=Gravitee.io&color=1EC9D2["Gravitee.io", link="https://download.gravitee.io/#graviteeio-apim/plugins/policies/gravitee-policy-retry/"]
 image:https://img.shields.io/badge/License-Apache%202.0-blue.svg["License", link="https://github.com/gravitee-io/gravitee-policy-retry /blob/master/LICENSE.txt"]
 image:https://circleci.com/gh/gravitee-io/gravitee-policy-retry.svg?style=svg["CircleCI", link="https://circleci.com/gh/gravitee-io/gravitee-policy-retry"]
 endif::[]

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,7 @@
 {
   "extends": [
     "config:base"
-  ]
+  ],
+  "prConcurrentLimit": 3,
+  "rebaseWhen": "conflicted"
 }


### PR DESCRIPTION
**Issue**

NA

**Description**

Small tooling improvements after a few days of use of both renovate and sematic release: 
 - add a badge in readme with a link to the download page
 - update Renovate config to limit CI runs
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

- 🚀 A prerelease version of this package has been published: `2.0.0.17553`
  <!-- Version placeholder end -->
