### PR TITLE
Upgrade project to use semantic-release

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -2,7 +2,8 @@
 
 ifdef::env-github[]
 image:https://img.shields.io/static/v1?label=Available%20at&message=Gravitee.io&color=1EC9D2["Gravitee.io", link="https://download.gravitee.io/#graviteeio-apim/plugins/policies/gravitee-policy-retry/"]
-image:https://img.shields.io/badge/License-Apache%202.0-blue.svg["License", link="https://github.com/gravitee-io/gravitee-policy-retry /blob/master/LICENSE.txt"]
+image:https://img.shields.io/badge/License-Apache%202.0-blue.svg["License", link="https://github.com/gravitee-io/gravitee-policy-retry/blob/master/LICENSE.txt"]
+image:https://img.shields.io/badge/semantic--release-conventional%20commits-e10079?logo=semantic-release["Releases", link="https://github.com/gravitee-io/gravitee-policy-retry/releases"]
 image:https://circleci.com/gh/gravitee-io/gravitee-policy-retry.svg?style=svg["CircleCI", link="https://circleci.com/gh/gravitee-io/gravitee-policy-retry"]
 endif::[]
 

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <properties>
         <gravitee-bom.version>1.4</gravitee-bom.version>
 
-        <gravitee-gateway-api.version>1.31.0-SNAPSHOT</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>1.31.0</gravitee-gateway-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-common.version>1.24.0</gravitee-common.version>
 


### PR DESCRIPTION
**Description**

Add badge on readme & bump a version to allow the release
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.1.0-upgrade-project-config`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-retry/2.1.0-upgrade-project-config/gravitee-policy-retry-2.1.0-upgrade-project-config.zip)
  <!-- Version placeholder end -->
