### PR TITLE
fix: fix retry counter start value and previous response canceling and test with sdk

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@2.0
+    gravitee: gravitee-io/gravitee@2.1
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)

--- a/README.adoc
+++ b/README.adoc
@@ -23,7 +23,7 @@ endif::[]
 
 You can use the `retry` policy to replay requests when experiencing backend connection issues or if the response meets a given _condition_.
 
-If the retry takes too long, relative to the `timeout` value, the request stops.
+If the retry takes too long, relative to the `timeout` value, the request stops and returns status code `502`.
 
 NOTE: To replay a request with a payload, the gateway stores it in memory. We recommend you avoid applying it to requests with a large payload.
 
@@ -40,7 +40,7 @@ You can enable or disable the policy with policy identifier `retry`.
 ^.^|X
 |Condition to test to determine whether or not to retry the request (supports Expression Language)
 ^.^| -
-^.^| {#response.status > 400}
+^.^| {#response.status > 500}
 
 .^|maxRetries
 ^.^|X
@@ -62,7 +62,7 @@ You can enable or disable the policy with policy identifier `retry`.
 
 .^|lastResponse
 ^.^|-
-|Returns the last attempt response, even if it failed
+|Returns the last attempt response, even if it failed regarding the configured condition. In timeout case, `502` is returned.
 ^.^| false
 ^.^| -
 
@@ -74,7 +74,7 @@ You can enable or disable the policy with policy identifier `retry`.
 ----
 {
   "retry": {
-    "condition": "{#response.status > 400}",
+    "condition": "{#response.status > 500}",
     "maxRetries": 3,
     "timeout": 1000
   }

--- a/README.adoc
+++ b/README.adoc
@@ -27,6 +27,15 @@ If the retry takes too long, relative to the `timeout` value, the request stops 
 
 NOTE: To replay a request with a payload, the gateway stores it in memory. We recommend you avoid applying it to requests with a large payload.
 
+== Compatibility with APIM
+
+|===
+|Plugin version | APIM version
+
+| 2.x and upper               | 3.10.x to latest
+| Up to 1.x                   | Up to 3.9.x
+|===
+
 === Policy identifier
 
 You can enable or disable the policy with policy identifier `retry`.

--- a/pom.xml
+++ b/pom.xml
@@ -34,9 +34,9 @@
     </parent>
 
     <properties>
-        <gravitee-bom.version>1.4</gravitee-bom.version>
+        <gravitee-bom.version>2.5</gravitee-bom.version>
 
-        <gravitee-gateway-api.version>1.31.0</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>1.32.2</gravitee-gateway-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-common.version>1.24.0</gravitee-common.version>
 
@@ -45,6 +45,8 @@
         </json-schema-generator-maven-plugin.outputDirectory>
 
         <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
+        <junit-jupiter.version>5.8.2</junit-jupiter.version>
+        <gravitee-apim-gateway-tests-sdk.version>3.18.0-SNAPSHOT</gravitee-apim-gateway-tests-sdk.version>
 
         <!-- Property used by the publication job in CI-->
         <publish-folder-path>graviteeio-apim/plugins/policies</publish-folder-path>
@@ -59,6 +61,13 @@
                 <version>${gravitee-bom.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${junit-jupiter.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -114,14 +123,15 @@
 
         <!-- Test scope -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
 
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
+            <groupId>io.gravitee.apim.gateway</groupId>
+            <artifactId>gravitee-apim-gateway-tests-sdk</artifactId>
+            <version>${gravitee-apim-gateway-tests-sdk.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -34,20 +34,16 @@
     </parent>
 
     <properties>
+        <gravitee-apim-gateway-tests-sdk.version>3.18.0-SNAPSHOT</gravitee-apim-gateway-tests-sdk.version>
         <gravitee-bom.version>2.5</gravitee-bom.version>
-
+        <gravitee-common.version>1.26.1</gravitee-common.version>
         <gravitee-gateway-api.version>1.32.2</gravitee-gateway-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
-        <gravitee-common.version>1.24.0</gravitee-common.version>
-
         <json-schema-generator-maven-plugin.version>1.3.0</json-schema-generator-maven-plugin.version>
         <json-schema-generator-maven-plugin.outputDirectory>${project.build.directory}/schemas
         </json-schema-generator-maven-plugin.outputDirectory>
 
         <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
-        <junit-jupiter.version>5.8.2</junit-jupiter.version>
-        <gravitee-apim-gateway-tests-sdk.version>3.18.0-SNAPSHOT</gravitee-apim-gateway-tests-sdk.version>
-
         <!-- Property used by the publication job in CI-->
         <publish-folder-path>graviteeio-apim/plugins/policies</publish-folder-path>
     </properties>
@@ -61,13 +57,6 @@
                 <version>${gravitee-bom.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
-            </dependency>
-            <dependency>
-                <groupId>org.junit</groupId>
-                <artifactId>junit-bom</artifactId>
-                <version>${junit-jupiter.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/src/test/java/io/gravitee/policy/retry/RetryPolicyIntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/retry/RetryPolicyIntegrationTest.java
@@ -1,0 +1,268 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.retry;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.notFound;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.stubbing.Scenario;
+import io.gravitee.apim.gateway.tests.sdk.AbstractPolicyTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.policy.retry.configuration.RetryPolicyConfiguration;
+import io.reactivex.observers.TestObserver;
+import io.vertx.reactivex.core.buffer.Buffer;
+import io.vertx.reactivex.ext.web.client.HttpResponse;
+import io.vertx.reactivex.ext.web.client.WebClient;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Thibaud AVENIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@GatewayTest
+@DeployApi("/apis/retry.json")
+class RetryPolicyIntegrationTest extends AbstractPolicyTest<RetryPolicy, RetryPolicyConfiguration> {
+
+    @Test
+    @DisplayName("Should succeed before max retries")
+    void shouldSucceedBeforeMaxRetries(WebClient client) {
+        wiremock.stubFor(
+            WireMock
+                .get("/endpoint")
+                .inScenario("retry")
+                .whenScenarioStateIs(Scenario.STARTED)
+                .willReturn(aResponse().withStatus(504))
+                .willSetStateTo("firstCall")
+        );
+        wiremock.stubFor(
+            WireMock
+                .get("/endpoint")
+                .inScenario("retry")
+                .whenScenarioStateIs("firstCall")
+                .willReturn(aResponse().withStatus(505))
+                .willSetStateTo("secondCall")
+        );
+        wiremock.stubFor(
+            WireMock
+                .get("/endpoint")
+                .inScenario("retry")
+                .whenScenarioStateIs("secondCall")
+                .willReturn(aResponse().withStatus(506))
+                .willReturn(ok())
+        );
+
+        final TestObserver<HttpResponse<Buffer>> obs = client.get("/test").rxSend().test();
+        awaitTerminalEvent(obs);
+
+        obs
+            .assertComplete()
+            .assertValue(response -> {
+                assertThat(response.statusCode()).isEqualTo(200);
+                return true;
+            })
+            .assertNoErrors();
+
+        wiremock.verify(3, getRequestedFor(urlPathEqualTo("/endpoint")));
+    }
+
+    @Test
+    @DisplayName("Should fail after max retries")
+    void shouldFailAfterMaxRetries(WebClient client) {
+        wiremock.stubFor(
+            WireMock
+                .get("/endpoint")
+                .inScenario("retry")
+                .whenScenarioStateIs(Scenario.STARTED)
+                .willReturn(aResponse().withStatus(505))
+                .willSetStateTo("firstCall")
+        );
+        wiremock.stubFor(
+            WireMock
+                .get("/endpoint")
+                .inScenario("retry")
+                .whenScenarioStateIs("firstCall")
+                .willReturn(aResponse().withStatus(506))
+                .willSetStateTo("secondCall")
+        );
+        wiremock.stubFor(
+            WireMock
+                .get("/endpoint")
+                .inScenario("retry")
+                .whenScenarioStateIs("secondCall")
+                .willReturn(aResponse().withStatus(507))
+                .willSetStateTo("thirdCall")
+        );
+        wiremock.stubFor(
+            WireMock.get("/endpoint").inScenario("retry").whenScenarioStateIs("thirdCall").willReturn(aResponse().withStatus(508))
+        );
+
+        final TestObserver<HttpResponse<Buffer>> obs = client.get("/test").rxSend().test();
+        awaitTerminalEvent(obs);
+
+        obs
+            .assertComplete()
+            .assertValue(response -> {
+                assertThat(response.statusCode()).isEqualTo(502);
+                return true;
+            })
+            .assertNoErrors();
+
+        wiremock.verify(4, getRequestedFor(urlPathEqualTo("/endpoint")));
+    }
+
+    @Test
+    @DisplayName("Should fail after all retries in timeout")
+    void shouldFailAfterTimeout(WebClient client) {
+        wiremock.stubFor(
+            WireMock
+                .get("/endpoint")
+                .inScenario("retry")
+                .whenScenarioStateIs(Scenario.STARTED)
+                .willReturn(ok().withFixedDelay(600))
+                .willSetStateTo("firstCall")
+        );
+        wiremock.stubFor(
+            WireMock
+                .get("/endpoint")
+                .inScenario("retry")
+                .whenScenarioStateIs("firstCall")
+                .willReturn(ok().withFixedDelay(600))
+                .willSetStateTo("secondCall")
+        );
+        wiremock.stubFor(
+            WireMock
+                .get("/endpoint")
+                .inScenario("retry")
+                .whenScenarioStateIs("secondCall")
+                .willReturn(ok().withFixedDelay(600))
+                .willSetStateTo("thirdCall")
+        );
+        wiremock.stubFor(
+            WireMock.get("/endpoint").inScenario("retry").whenScenarioStateIs("thirdCall").willReturn(ok().withFixedDelay(600))
+        );
+
+        final TestObserver<HttpResponse<Buffer>> obs = client.get("/test").rxSend().test();
+        awaitTerminalEvent(obs);
+
+        obs
+            .assertComplete()
+            .assertValue(response -> {
+                assertThat(response.statusCode()).isEqualTo(502);
+                return true;
+            })
+            .assertNoErrors();
+
+        wiremock.verify(4, getRequestedFor(urlPathEqualTo("/endpoint")));
+    }
+
+    @Test
+    @DeployApi("/apis/retry-last-response.json")
+    @DisplayName("Should fail after too many conditions failure and return last response")
+    void shouldFailAfterTooManyConditionFailureAndReturnLastResponse(WebClient client) {
+        wiremock.stubFor(
+            WireMock
+                .get("/endpoint")
+                .inScenario("retry")
+                .whenScenarioStateIs(Scenario.STARTED)
+                .willReturn(notFound())
+                .willSetStateTo("firstCall")
+        );
+        wiremock.stubFor(
+            WireMock
+                .get("/endpoint")
+                .inScenario("retry")
+                .whenScenarioStateIs("firstCall")
+                .willReturn(notFound())
+                .willSetStateTo("secondCall")
+        );
+        wiremock.stubFor(
+            WireMock
+                .get("/endpoint")
+                .inScenario("retry")
+                .whenScenarioStateIs("secondCall")
+                .willReturn(notFound())
+                .willSetStateTo("thirdCall")
+        );
+        wiremock.stubFor(WireMock.get("/endpoint").inScenario("retry").whenScenarioStateIs("thirdCall").willReturn(notFound()));
+
+        final TestObserver<HttpResponse<Buffer>> obs = client.get("/test-last-response").rxSend().test();
+        awaitTerminalEvent(obs);
+
+        obs
+            .assertComplete()
+            .assertValue(response -> {
+                assertThat(response.statusCode()).isEqualTo(404);
+                return true;
+            })
+            .assertNoErrors();
+
+        wiremock.verify(4, getRequestedFor(urlPathEqualTo("/endpoint")));
+    }
+
+    @Test
+    @DeployApi("/apis/retry-last-response.json")
+    @DisplayName("Should fail after too many timeout failures and does not return last response")
+    void shouldFailAfterTimeoutAndReturnLastResponse(WebClient client) {
+        wiremock.stubFor(
+            WireMock
+                .get("/endpoint")
+                .inScenario("retry")
+                .whenScenarioStateIs(Scenario.STARTED)
+                .willReturn(ok().withFixedDelay(600))
+                .willSetStateTo("firstCall")
+        );
+        wiremock.stubFor(
+            WireMock
+                .get("/endpoint")
+                .inScenario("retry")
+                .whenScenarioStateIs("firstCall")
+                .willReturn(ok().withFixedDelay(600))
+                .willSetStateTo("secondCall")
+        );
+        wiremock.stubFor(
+            WireMock
+                .get("/endpoint")
+                .inScenario("retry")
+                .whenScenarioStateIs("secondCall")
+                .willReturn(ok().withFixedDelay(600))
+                .willSetStateTo("thirdCall")
+        );
+        wiremock.stubFor(
+            WireMock.get("/endpoint").inScenario("retry").whenScenarioStateIs("thirdCall").willReturn(ok().withFixedDelay(600))
+        );
+
+        final TestObserver<HttpResponse<Buffer>> obs = client.get("/test-last-response").rxSend().test();
+        awaitTerminalEvent(obs);
+
+        obs
+            .assertComplete()
+            .assertValue(response -> {
+                // In the case of a timeout, lastResponse option does not do anything
+                assertThat(response.statusCode()).isEqualTo(502);
+                return true;
+            })
+            .assertNoErrors();
+
+        wiremock.verify(4, getRequestedFor(urlPathEqualTo("/endpoint")));
+    }
+}

--- a/src/test/resources/apis/retry-last-response.json
+++ b/src/test/resources/apis/retry-last-response.json
@@ -1,0 +1,46 @@
+{
+  "id": "my-api-last-response",
+  "name": "my-api",
+  "gravitee": "2.0.0",
+  "proxy": {
+    "context_path": "/test-last-response",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://localhost:8080/endpoint",
+        "http": {
+          "connectTimeout": 3000,
+          "readTimeout": 60000
+        }
+      }
+    ]
+  },
+  "flows": [
+    {
+      "name": "flow-1",
+      "methods": [
+        "GET"
+      ],
+      "enabled": true,
+      "path-operator": {
+        "path": "/",
+        "operator": "STARTS_WITH"
+      },
+      "pre": [
+        {
+          "name": "Retry",
+          "description": "",
+          "enabled": true,
+          "policy": "retry",
+          "configuration": {
+            "condition": "{#response.status > 400}",
+            "maxRetries": 3,
+            "timeout": 500,
+            "lastResponse": true
+          }
+        }
+      ],
+      "post": []
+    }
+  ]
+}

--- a/src/test/resources/apis/retry.json
+++ b/src/test/resources/apis/retry.json
@@ -1,0 +1,45 @@
+{
+  "id": "my-api",
+  "name": "my-api",
+  "gravitee": "2.0.0",
+  "proxy": {
+    "context_path": "/test",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://localhost:8080/endpoint",
+        "http": {
+          "connectTimeout": 2000,
+          "readTimeout": 60000
+        }
+      }
+    ]
+  },
+  "flows": [
+    {
+      "name": "flow-1",
+      "methods": [
+        "GET"
+      ],
+      "enabled": true,
+      "path-operator": {
+        "path": "/",
+        "operator": "STARTS_WITH"
+      },
+      "pre": [
+        {
+          "name": "Retry",
+          "description": "",
+          "enabled": true,
+          "policy": "retry",
+          "configuration": {
+            "condition": "{#response.status > 500}",
+            "maxRetries": 3,
+            "timeout": 500
+          }
+        }
+      ],
+      "post": []
+    }
+  ]
+}

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+	<appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+		<layout class="ch.qos.logback.classic.PatternLayout">
+			<Pattern>
+				%date{yyyy-MM-dd HH:mm:ss.SSS} [%-5p] %c: %m%n
+			</Pattern>
+		</layout>
+	</appender>
+
+	<!-- only gravitee Logs in debug -->
+	<logger name="io.gravitee" level="debug" additivity="false">
+		<appender-ref ref="CONSOLE" />
+	</logger>
+
+	<!-- Root Logger -->
+	<root level="warn">
+		<appender-ref ref="CONSOLE" />
+	</root>
+
+</configuration>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7747

**Description**

previous proxyResponse were not properly canceled on each retry, making them continuing to live. In the case of integration testing, we discovered it prevents the Gateway to shutdown gracefully and quickly because of not terminated requests. In real life, it would have been a problem if we needed to stop quickly a gateway
counter of retries was compared to the maxRetry parameter, but the counter was including the first real call to the policy. In case of lastResponse=true, we were returning the issue before the last configured reply.

- [x] properly cancel previous `proxyResponse` to avoid having them continuing solely in space
- [x] start retry counter at -1 to not take into account the first real call to endpoint
- [x] improve documentation
- [x] use sdk with some testcases: timeout with/without lastResponse, condition fail with/without lastResponse


<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.1.2-issues-7747-retry-tests-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-retry/2.1.2-issues-7747-retry-tests-SNAPSHOT/gravitee-policy-retry-2.1.2-issues-7747-retry-tests-SNAPSHOT.zip)
  <!-- Version placeholder end -->
