### PR TITLE
fix:Retry Policy crashing on "big" body payload

### DIFF
--- a/src/main/java/io/gravitee/policy/retry/ReplayingReadStream.java
+++ b/src/main/java/io/gravitee/policy/retry/ReplayingReadStream.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.retry;
+
+import io.gravitee.gateway.api.buffer.Buffer;
+import io.gravitee.gateway.api.handler.Handler;
+import io.gravitee.gateway.api.stream.ReadStream;
+
+public class ReplayingReadStream implements ReadStream<Buffer> {
+
+    private final Buffer cachedBody;
+    private final boolean bodyEnded;
+
+    private Handler<Buffer> bodyHandler;
+    private Handler<Void> endHandler;
+
+    public ReplayingReadStream(Buffer cachedBody, boolean bodyEnded) {
+        this.cachedBody = cachedBody;
+        this.bodyEnded = bodyEnded;
+    }
+
+    @Override
+    public ReadStream<Buffer> bodyHandler(Handler<Buffer> handler) {
+        this.bodyHandler = handler;
+        if (cachedBody != null && handler != null) {
+            handler.handle(cachedBody);
+        }
+        return this;
+    }
+
+    @Override
+    public ReadStream<Buffer> endHandler(Handler<Void> handler) {
+        this.endHandler = handler;
+        if (bodyEnded && handler != null) {
+            handler.handle(null);
+        }
+        return this;
+    }
+
+    @Override
+    public ReadStream<Buffer> pause() {
+        return this;
+    }
+
+    @Override
+    public ReadStream<Buffer> resume() {
+        return this;
+    }
+}

--- a/src/main/java/io/gravitee/policy/retry/RetryReadStream.java
+++ b/src/main/java/io/gravitee/policy/retry/RetryReadStream.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.retry;
+
+import io.gravitee.gateway.api.buffer.Buffer;
+import io.gravitee.gateway.api.handler.Handler;
+import io.gravitee.gateway.api.stream.ReadStream;
+import java.util.ArrayList;
+import java.util.List;
+
+public class RetryReadStream implements ReadStream<Buffer> {
+
+    private final ReadStream<Buffer> source;
+    private final List<Buffer> cachedChunks = new ArrayList<>();
+
+    private Handler<Buffer> bodyHandler;
+    private Handler<Void> endHandler;
+
+    private boolean ended = false;
+    private boolean resumed = false;
+    private boolean replaying = false;
+
+    public RetryReadStream(ReadStream<Buffer> source) {
+        this.source = source;
+        wireHandlers();
+    }
+
+    private void wireHandlers() {
+        source.bodyHandler(chunk -> {
+            cachedChunks.add(chunk);
+            if (!replaying && bodyHandler != null) {
+                bodyHandler.handle(chunk);
+            }
+        });
+
+        source.endHandler(v -> {
+            ended = true;
+            if (!replaying && endHandler != null) {
+                endHandler.handle(null);
+            }
+        });
+    }
+
+    @Override
+    public ReadStream<Buffer> bodyHandler(Handler<Buffer> handler) {
+        this.bodyHandler = handler;
+        return this;
+    }
+
+    @Override
+    public ReadStream<Buffer> endHandler(Handler<Void> handler) {
+        this.endHandler = handler;
+        return this;
+    }
+
+    @Override
+    public ReadStream<Buffer> pause() {
+        source.pause();
+        return this;
+    }
+
+    @Override
+    public ReadStream<Buffer> resume() {
+        if (!resumed) {
+            resumed = true;
+            source.resume();
+        } else if (ended && !replaying) {
+            replaying = true;
+            for (Buffer chunk : cachedChunks) {
+                if (bodyHandler != null) bodyHandler.handle(chunk);
+            }
+            if (endHandler != null) endHandler.handle(null);
+        }
+        return this;
+    }
+
+    public boolean hasEnded() {
+        return ended;
+    }
+}

--- a/src/test/java/io/gravitee/policy/retry/ReplayingReadStreamTest.java
+++ b/src/test/java/io/gravitee/policy/retry/ReplayingReadStreamTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.retry;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import io.gravitee.gateway.api.buffer.Buffer;
+import io.gravitee.gateway.api.handler.Handler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class ReplayingReadStreamTest {
+
+    private ReplayingReadStream replayingReadStream;
+    private Buffer buffer;
+
+    @BeforeEach
+    void setUp() {
+        buffer = Buffer.buffer("test-data");
+        replayingReadStream = new ReplayingReadStream(buffer, true);
+    }
+
+    @Test
+    void testBodyHandlerIsCalledWithBufferedData() {
+        Handler<Buffer> bodyHandler = mock(Handler.class);
+        replayingReadStream.bodyHandler(bodyHandler);
+        verify(bodyHandler).handle(buffer);
+    }
+
+    @Test
+    void testEndHandlerIsCalled() {
+        Handler<Void> endHandler = mock(Handler.class);
+        replayingReadStream.endHandler(endHandler);
+        verify(endHandler).handle(null);
+    }
+
+    @Test
+    void testMultipleChunksReplayedCorrectly() {
+        Buffer combined = Buffer.buffer();
+        combined.appendBuffer(Buffer.buffer("chunk1"));
+        combined.appendBuffer(Buffer.buffer("chunk2"));
+        replayingReadStream = new ReplayingReadStream(combined, true);
+
+        Handler<Buffer> bodyHandler = mock(Handler.class);
+        replayingReadStream.bodyHandler(bodyHandler);
+        verify(bodyHandler).handle(combined);
+    }
+}

--- a/src/test/java/io/gravitee/policy/retry/RetryReadStreamTest.java
+++ b/src/test/java/io/gravitee/policy/retry/RetryReadStreamTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.retry;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.gravitee.gateway.api.buffer.Buffer;
+import io.gravitee.gateway.api.handler.Handler;
+import io.gravitee.gateway.api.stream.ReadStream;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class RetryReadStreamTest {
+
+    private FakeReadStream originalStream;
+    private RetryReadStream retryStream;
+
+    @BeforeEach
+    void setUp() {
+        originalStream = new FakeReadStream();
+        retryStream = new RetryReadStream(originalStream);
+    }
+
+    @Test
+    void shouldBufferAndReplayBody() {
+        AtomicReference<Buffer> received = new AtomicReference<>();
+        AtomicBoolean endCalled = new AtomicBoolean(false);
+
+        retryStream.bodyHandler(received::set);
+        retryStream.endHandler(v -> endCalled.set(true));
+
+        Buffer chunk = Buffer.buffer("test-body");
+        originalStream.emit(chunk);
+        originalStream.complete();
+
+        assertTrue(endCalled.get(), "End handler should be triggered");
+        assertEquals("test-body", received.get().toString(), "Body should match");
+    }
+
+    static class FakeReadStream implements ReadStream<Buffer> {
+
+        private Handler<Buffer> bodyHandler;
+        private Handler<Void> endHandler;
+
+        @Override
+        public ReadStream<Buffer> bodyHandler(Handler<Buffer> handler) {
+            this.bodyHandler = handler;
+            return this;
+        }
+
+        @Override
+        public ReadStream<Buffer> endHandler(Handler<Void> handler) {
+            this.endHandler = handler;
+            return this;
+        }
+
+        @Override
+        public ReadStream<Buffer> pause() {
+            return this;
+        }
+
+        @Override
+        public ReadStream<Buffer> resume() {
+            return this;
+        }
+
+        void emit(Buffer chunk) {
+            if (bodyHandler != null) bodyHandler.handle(chunk);
+        }
+
+        void complete() {
+            if (endHandler != null) endHandler.handle(null);
+        }
+    }
+}


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-9569

**Description**

Retry Policy crashing on "big" body payload
this scenario was failing because we reused a one-time readStream, which loses the body after the first call.
Made below changes

- Caching the body
- Wrapping bodyHandler and endHandler,
- And replaying them during retry.

This made retries safe for POST payloads.
below is the video of working on local.


https://github.com/user-attachments/assets/5bff44d0-2434-4343-96f0-7cff128905f8




**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.1-APIM-9569-Retry-Policy-crashing-on-big-body-payload-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-retry/3.0.1-APIM-9569-Retry-Policy-crashing-on-big-body-payload-SNAPSHOT/gravitee-policy-retry-3.0.1-APIM-9569-Retry-Policy-crashing-on-big-body-payload-SNAPSHOT.zip)
  <!-- Version placeholder end -->
