### PR TITLE
feat: enable for A2A proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The `retry` policy can be applied to the following API types and flow phases.
 * `PROXY`
 * `MCP PROXY`
 * `LLM PROXY`
+* `A2A PROXY`
 
 ### Supported flow phases:
 

--- a/src/main/resources/plugin.properties
+++ b/src/main/resources/plugin.properties
@@ -11,3 +11,4 @@ category=others
 http_proxy=REQUEST
 mcp_proxy=REQUEST
 llm_proxy=REQUEST
+a2a_proxy=REQUEST


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-12548

**Description**

Enable for A2A proxy.

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.1.0-apim-12548-enable-for-a2a-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-retry/4.1.0-apim-12548-enable-for-a2a-SNAPSHOT/gravitee-policy-retry-4.1.0-apim-12548-enable-for-a2a-SNAPSHOT.zip)
  <!-- Version placeholder end -->
