### PR TITLE
fix: preserve dynamic routing endpoint across retries

### DIFF
--- a/src/main/java/io/gravitee/policy/retry/RetryPolicy.java
+++ b/src/main/java/io/gravitee/policy/retry/RetryPolicy.java
@@ -83,10 +83,12 @@ public class RetryPolicy extends RetryPolicyV3 implements HttpPolicy {
             // Setting it to -1 prevent counting this first call as a retry.
             final AtomicInteger counter = new AtomicInteger(-1);
 
+            // Capture once: the invoker mutates this attribute on each call, so re-reading inside defer would lose the original across retries.
+            final var originalEndpoint = ctx.getAttribute(ATTR_REQUEST_ENDPOINT);
+
             return Completable
                 .defer(() -> {
                     counter.incrementAndGet();
-                    var originalEndpoint = ctx.getAttribute(ATTR_REQUEST_ENDPOINT);
                     // EndpointInvoker overrides the request endpoint. We need to set it back to the original state to retry properly
                     ctx.setAttribute(ATTR_REQUEST_ENDPOINT, originalEndpoint);
                     // Entrypoint connectors skip response handling if there is an error. In the case of a retry, we need to reset the failure.

--- a/src/test/java/io/gravitee/policy/retry/RetryPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/retry/RetryPolicyTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.retry;
+
+import static io.gravitee.gateway.reactive.api.context.ContextAttributes.ATTR_REQUEST_ENDPOINT;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.gateway.reactive.api.context.http.HttpExecutionContext;
+import io.gravitee.gateway.reactive.api.context.http.HttpRequest;
+import io.gravitee.gateway.reactive.api.invoker.HttpInvoker;
+import io.gravitee.policy.retry.configuration.RetryPolicyConfiguration;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Maybe;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class RetryPolicyTest {
+
+    private static final String ORIGINAL_ENDPOINT = "bs:/path";
+    private static final String STRIPPED_ENDPOINT = "/path";
+
+    private HttpExecutionContext ctx;
+    private HttpRequest request;
+    private HttpInvoker delegate;
+    private RetryPolicyConfiguration configuration;
+
+    @BeforeEach
+    void setUp() {
+        ctx = mock(HttpExecutionContext.class);
+        request = mock(HttpRequest.class);
+        delegate = mock(HttpInvoker.class);
+
+        configuration = new RetryPolicyConfiguration();
+        configuration.setMaxRetries(2);
+        configuration.setTimeout(10_000L);
+        configuration.setDelay(0L);
+
+        when(ctx.request()).thenReturn(request);
+        when(request.body()).thenReturn(Maybe.empty());
+        when(ctx.interruptWith(any())).thenReturn(Completable.complete());
+    }
+
+    @Test
+    void should_restore_original_endpoint_attribute_on_each_retry_when_invoker_mutates_it() {
+        // Stub get/set to round-trip through `stored` so the mock reflects state mutations.
+        AtomicReference<String> stored = new AtomicReference<>(ORIGINAL_ENDPOINT);
+        when(ctx.<String>getAttribute(ATTR_REQUEST_ENDPOINT)).thenAnswer(inv -> stored.get());
+        doAnswer(inv -> {
+                stored.set(inv.getArgument(1));
+                return null;
+            })
+            .when(ctx)
+            .setAttribute(eq(ATTR_REQUEST_ENDPOINT), any());
+
+        // Delegate mimics HttpEndpointInvoker: strips the prefix from the attribute, then errors to trigger a retry.
+        when(delegate.invoke(ctx))
+            .thenAnswer(inv -> {
+                ctx.setAttribute(ATTR_REQUEST_ENDPOINT, STRIPPED_ENDPOINT);
+                return Completable.error(new RuntimeException("simulated upstream failure"));
+            });
+
+        new RetryPolicy.RetryInvoker(delegate, configuration).invoke(ctx).test().awaitDone(5, TimeUnit.SECONDS);
+
+        // Each attempt must restore the original value before invoking the delegate; otherwise a later attempt reads the stripped value back.
+        // InOrder guards against a refactor that invokes the delegate before restoring the attribute.
+        InOrder inOrder = inOrder(ctx, delegate);
+        for (int attempt = 1; attempt <= 3; attempt++) {
+            inOrder.verify(ctx).setAttribute(eq(ATTR_REQUEST_ENDPOINT), eq(ORIGINAL_ENDPOINT));
+            inOrder.verify(delegate).invoke(ctx);
+        }
+    }
+}


### PR DESCRIPTION
Fixes [APIM-14106](https://gravitee.atlassian.net/browse/APIM-14106).

`RetryPolicy.RetryInvoker.invoke` captured `originalEndpoint = ctx.getAttribute(ATTR_REQUEST_ENDPOINT)` inside `Completable.defer(...)`, so the re-evaluated closure on each retry re-read the attribute *after* the previous attempt's `HttpEndpointInvoker` had stripped the endpoint-reference prefix. From the 2nd attempt onward, the restored value was the stripped path, the endpoint name was lost, and the request fell back to the default endpoint group — defeating Dynamic Routing for any flow that combined DR with Retry on a timeout-prone cold connection.

## Changes
- `RetryPolicy.java`: capture `originalEndpoint` once before `Completable.defer(...)`, matching the proven pattern in apim-gateway's `FailoverInvoker`.
- `RetryPolicyTest.java`: new unit test that simulates the `HttpEndpointInvoker` prefix-strip and uses `InOrder` to assert `restore → invoke` happens on every attempt. Verified to fail against the pre-fix code.

## Test plan
- [x] `mvn test` — 19/19 pass (12 V4 + 6 V3 integration + 1 new unit test)
- [x] Regression catch confirmed: test fails against `origin/master` production code with "Wanted but not invoked... Wanted anywhere AFTER following interaction"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[APIM-14106]: https://gravitee.atlassian.net/browse/APIM-14106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.1.1-apim-14106-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-retry/4.1.1-apim-14106-SNAPSHOT/gravitee-policy-retry-4.1.1-apim-14106-SNAPSHOT.zip)
  <!-- Version placeholder end -->
