### PR TITLE
fix!: compatibility to vertx 5

### DIFF
--- a/.docgen/matrix.yaml
+++ b/.docgen/matrix.yaml
@@ -9,5 +9,9 @@ rows:
           java: 17
     - data:
           plugin: "4.x"
-          apim: "4.9.x and later"
+          apim: "4.9.x to 4.11.x"
+          java: 21
+    - data:
+          plugin: "5.x"
+          apim: "4.12.x and later"
           java: 21

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ Strikethrough text indicates that a version is deprecated.
 | --- | --- | ---  |
 |2.x|4.5.x and earlier|17 |
 |3.x|4.6.x to 4.8.x|17 |
-|4.x|4.9.x and later|21 |
+|4.x|4.9.x to 4.11.x|21 |
+|5.x|4.12.x and later|21 |
 
 
 ## Configuration options

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,3 @@
+lombok.addLombokGeneratedAnnotation = true
+config.stopBubbling = true
+lombok.log.custom.declaration = org.slf4j.Logger io.gravitee.node.logging.NodeLoggerFactory.getLogger(TYPE)

--- a/pom.xml
+++ b/pom.xml
@@ -30,12 +30,12 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>23.4.1</version>
+        <version>24.0.2</version>
     </parent>
 
     <properties>
         <!-- Gravitee dependencies version -->
-        <gravitee-apim-bom.version>4.9.0</gravitee-apim-bom.version>
+        <gravitee-apim-bom.version>4.12.0</gravitee-apim-bom.version>
 
         <!-- Other dependencies version -->
         <resilience4j-retry.version>2.2.0</resilience4j-retry.version>
@@ -73,6 +73,11 @@
             <artifactId>gravitee-policy-api</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>io.gravitee.node</groupId>
+            <artifactId>gravitee-node-logging</artifactId>
+            <scope>provided</scope>
+        </dependency>
 
         <!-- Vert.x -->
         <dependency>
@@ -94,16 +99,27 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- Logging -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <scope>test</scope>
+            <artifactId>logback-core</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <!-- Test scope -->
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/io/gravitee/policy/retry/RetryPolicy.java
+++ b/src/main/java/io/gravitee/policy/retry/RetryPolicy.java
@@ -28,11 +28,12 @@ import io.gravitee.gateway.reactive.api.invoker.HttpInvoker;
 import io.gravitee.gateway.reactive.api.policy.http.HttpPolicy;
 import io.gravitee.policy.retry.configuration.RetryPolicyConfiguration;
 import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Flowable;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import lombok.extern.slf4j.Slf4j;
+import lombok.CustomLog;
 
-@Slf4j
+@CustomLog
 public class RetryPolicy extends RetryPolicyV3 implements HttpPolicy {
 
     private static final long DEFAULT_TIMEOUT = 1000L;
@@ -86,16 +87,15 @@ public class RetryPolicy extends RetryPolicyV3 implements HttpPolicy {
             // Capture once: the invoker mutates this attribute on each call, so re-reading inside defer would lose the original across retries.
             final var originalEndpoint = ctx.getAttribute(ATTR_REQUEST_ENDPOINT);
 
-            return Completable
-                .defer(() -> {
-                    counter.incrementAndGet();
-                    // EndpointInvoker overrides the request endpoint. We need to set it back to the original state to retry properly
-                    ctx.setAttribute(ATTR_REQUEST_ENDPOINT, originalEndpoint);
-                    // Entrypoint connectors skip response handling if there is an error. In the case of a retry, we need to reset the failure.
-                    ctx.removeInternalAttribute(ATTR_INTERNAL_EXECUTION_FAILURE);
-                    // Consume the body and ignore it. Consuming it with .body() method internally enables caching of chunks, which is mandatory to retry the request in case of failure.
-                    return ctx.request().body().ignoreElement().andThen(invoker.invoke(ctx));
-                })
+            return Completable.defer(() -> {
+                counter.incrementAndGet();
+                // EndpointInvoker overrides the request endpoint. We need to set it back to the original state to retry properly
+                ctx.setAttribute(ATTR_REQUEST_ENDPOINT, originalEndpoint);
+                // Entrypoint connectors skip response handling if there is an error. In the case of a retry, we need to reset the failure.
+                ctx.removeInternalAttribute(ATTR_INTERNAL_EXECUTION_FAILURE);
+                // Consume the body and ignore it. Consuming it with .body() method internally enables caching of chunks, which is mandatory to retry the request in case of failure.
+                return ctx.request().body().ignoreElement().andThen(invoker.invoke(ctx));
+            })
                 .andThen(
                     Completable.defer(() -> {
                         ctx.getTemplateEngine().getTemplateContext().setVariable(TEMPLATE_RESPONSE_VARIABLE, ctx.response());
@@ -113,8 +113,14 @@ public class RetryPolicy extends RetryPolicyV3 implements HttpPolicy {
                 .timeout(timeout, timeUnit)
                 .compose(RxHelper.retryCompletable(maxRetries, (int) delay, timeUnit))
                 .onErrorResumeNext(t -> {
+                    // Any error path here (timeout, exhausted retries, condition failure) may leave
+                    // ctx.response().chunks() pointing to a FlowableProxyResponse that was never initialized -- for a
+                    // timed-out attempt the backend never answered before the timeout disposed the invoker, so its ctx is
+                    // null. Reset the chunks unconditionally, otherwise sending the 502 error response subscribes to it
+                    // and throws NPE.
+                    ctx.response().chunks(Flowable.empty());
                     String apiId = ctx.getAttribute(ATTR_API);
-                    log.info("[apiId={}] Retry failed after {} retries", apiId, configuration.getMaxRetries());
+                    ctx.withLogger(log).info("[apiId={}] Retry failed after {} retries", apiId, configuration.getMaxRetries());
                     return ctx.interruptWith(new ExecutionFailure(502).cause(t));
                 });
         }

--- a/src/main/java/io/gravitee/policy/retry/RetryPolicyV3.java
+++ b/src/main/java/io/gravitee/policy/retry/RetryPolicyV3.java
@@ -35,7 +35,6 @@ import io.gravitee.policy.retry.configuration.RetryPolicyConfiguration;
 import io.gravitee.policy.retry.el.ProxyResponseWrapper;
 import io.vertx.circuitbreaker.CircuitBreaker;
 import io.vertx.circuitbreaker.CircuitBreakerOptions;
-import io.vertx.core.AsyncResult;
 import io.vertx.core.Vertx;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -89,7 +88,7 @@ public class RetryPolicyV3 {
             );
 
             if (configuration.getDelay() > 0) {
-                circuitBreaker.retryPolicy(integer -> configuration.getDelay());
+                circuitBreaker.retryPolicy((failure, retryCount) -> configuration.getDelay());
             }
 
             // The circuit breaker is used for the first real call to the backend, before the retries.
@@ -97,49 +96,45 @@ public class RetryPolicyV3 {
             final AtomicInteger counter = new AtomicInteger(-1);
             final AtomicReference<ProxyResponse> proxyResponseRef = new AtomicReference<>();
 
-            circuitBreaker.execute(
-                event -> {
+            circuitBreaker
+                .<RetryProxyConnection>execute(event -> {
                     counter.incrementAndGet();
 
                     // Mark the request as 'retry' if any.
                     retryRequest.markRetry(counter.get() > 0);
 
                     // Listen for the response from backend
-                    invoker.invoke(
-                        context,
-                        readStream,
-                        connection -> {
-                            connection
-                                .exceptionHandler(event::fail)
-                                .responseHandler(proxyResponse -> {
-                                    // cancel the previous proxyResponse if it exists
-                                    cancelProxyResponse(proxyResponseRef.getAndSet(proxyResponse));
-                                    context
-                                        .getTemplateEngine()
-                                        .getTemplateContext()
-                                        .setVariable(
-                                            TEMPLATE_RESPONSE_VARIABLE,
-                                            // Note: we must create a EvaluableResponse and a ProxyResponseWrapper to make sure classloader will be well released when the api is undeployed.
-                                            new EvaluableResponse(new ProxyResponseWrapper(proxyResponse))
-                                        );
-                                    boolean retry = context.getTemplateEngine().getValue(configuration.getCondition(), boolean.class);
+                    invoker.invoke(context, readStream, connection -> {
+                        connection
+                            .exceptionHandler(event::fail)
+                            .responseHandler(proxyResponse -> {
+                                // cancel the previous proxyResponse if it exists
+                                cancelProxyResponse(proxyResponseRef.getAndSet(proxyResponse));
+                                context
+                                    .getTemplateEngine()
+                                    .getTemplateContext()
+                                    .setVariable(
+                                        TEMPLATE_RESPONSE_VARIABLE,
+                                        // Note: we must create a EvaluableResponse and a ProxyResponseWrapper to make sure classloader will be well released when the api is undeployed.
+                                        new EvaluableResponse(new ProxyResponseWrapper(proxyResponse))
+                                    );
+                                boolean retry = context.getTemplateEngine().evalNow(configuration.getCondition(), boolean.class);
 
-                                    if (retry) {
-                                        if (configuration.isLastResponse() && counter.get() == configuration.getMaxRetries()) {
-                                            event.complete(new RetryProxyConnection(connection, proxyResponse));
-                                        } else {
-                                            // Cleanup by cancelling the proxyResponse (request tracker, ...).
-                                            proxyResponse.cancel();
-                                            event.fail("");
-                                        }
-                                    } else {
+                                if (retry) {
+                                    if (configuration.isLastResponse() && counter.get() == configuration.getMaxRetries()) {
                                         event.complete(new RetryProxyConnection(connection, proxyResponse));
+                                    } else {
+                                        // Cleanup by cancelling the proxyResponse (request tracker, ...).
+                                        proxyResponse.cancel();
+                                        event.fail("");
                                     }
-                                });
-                        }
-                    );
-                },
-                (io.vertx.core.Handler<AsyncResult<RetryProxyConnection>>) event -> {
+                                } else {
+                                    event.complete(new RetryProxyConnection(connection, proxyResponse));
+                                }
+                            });
+                    });
+                })
+                .onComplete(event -> {
                     circuitBreaker.close();
 
                     if (event.succeeded()) {
@@ -153,8 +148,7 @@ public class RetryPolicyV3 {
                         handler.handle(connection);
                         connection.sendResponse();
                     }
-                }
-            );
+                });
         }
 
         private void cancelProxyResponse(ProxyResponse previous) {

--- a/src/test/java/io/gravitee/policy/retry/RetryPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/retry/RetryPolicyTest.java
@@ -70,18 +70,17 @@ class RetryPolicyTest {
         AtomicReference<String> stored = new AtomicReference<>(ORIGINAL_ENDPOINT);
         when(ctx.<String>getAttribute(ATTR_REQUEST_ENDPOINT)).thenAnswer(inv -> stored.get());
         doAnswer(inv -> {
-                stored.set(inv.getArgument(1));
-                return null;
-            })
+            stored.set(inv.getArgument(1));
+            return null;
+        })
             .when(ctx)
             .setAttribute(eq(ATTR_REQUEST_ENDPOINT), any());
 
         // Delegate mimics HttpEndpointInvoker: strips the prefix from the attribute, then errors to trigger a retry.
-        when(delegate.invoke(ctx))
-            .thenAnswer(inv -> {
-                ctx.setAttribute(ATTR_REQUEST_ENDPOINT, STRIPPED_ENDPOINT);
-                return Completable.error(new RuntimeException("simulated upstream failure"));
-            });
+        when(delegate.invoke(ctx)).thenAnswer(inv -> {
+            ctx.setAttribute(ATTR_REQUEST_ENDPOINT, STRIPPED_ENDPOINT);
+            return Completable.error(new RuntimeException("simulated upstream failure"));
+        });
 
         new RetryPolicy.RetryInvoker(delegate, configuration).invoke(ctx).test().awaitDone(5, TimeUnit.SECONDS);
 


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-14815

**Description**

BREAKING CHANGE: depends on APIM 4.12
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.0.0-mba-fix-vertx-5-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-retry/5.0.0-mba-fix-vertx-5-SNAPSHOT/gravitee-policy-retry-5.0.0-mba-fix-vertx-5-SNAPSHOT.zip)
  <!-- Version placeholder end -->
